### PR TITLE
AB2D-5434 Update Properties service to use own schema

### DIFF
--- a/Jenkinsfile.deployment
+++ b/Jenkinsfile.deployment
@@ -19,7 +19,7 @@ pipeline {
         stage ('Build Libraries') {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'artifactoryuserpass', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PASSWORD')]) { 
-                    sh 'gradle -b build.gradle bootJar -Dset.root.project.build.filename=true '
+                    sh 'gradle -b build.gradle clean bootJar -Dset.root.project.build.filename=true '
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'org.cyclonedx.bom' version '1.7.4' apply true
 }
 
-version = '1.0.3'
+version = '1.1.0'
 group = "gov.cms.ab2d"
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'org.cyclonedx.bom' version '1.7.4' apply true
 }
 
-version = '1.1.0'
+version = "1.0.3"
 group = "gov.cms.ab2d"
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'org.springframework.boot' version '2.7.5'
     id 'com.jfrog.artifactory' version '4.33.1' apply false
     id "org.sonarqube" version "4.3.0.3225"
-    id "gov.cms.ab2d.plugin" version "0.0.1-SNAPSHOT"
+    id "gov.cms.ab2d.plugin" version "1.0.2"
     id "maven-publish"
     id 'jacoco'
     id 'org.cyclonedx.bom' version '1.7.4' apply true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,5 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none
 
 server.port=8060
+
+spring.liquibase.liquibase-schema=property

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,7 @@
 databaseChangeLog:
   - include:
       file: db/changelog/v2022/create_schema.sql
+  - include:
+      file: db/changelog/v2023/create_properties.sql
+  - include:
+      file: db/changelog/v2023/add_optout_property.sql

--- a/src/main/resources/db/changelog/v2023/add_optout_property.sql
+++ b/src/main/resources/db/changelog/v2023/add_optout_property.sql
@@ -1,0 +1,4 @@
+INSERT INTO property.properties(id, key, value, created, modified)
+VALUES (nextval('hibernate_sequence'), 'OptOutOn', 'false', current_timestamp, current_timestamp);
+
+--rollback DELETE FROM properties WHERE key = 'OptOutOn';

--- a/src/main/resources/db/changelog/v2023/add_optout_property.sql
+++ b/src/main/resources/db/changelog/v2023/add_optout_property.sql
@@ -1,4 +1,4 @@
 INSERT INTO property.properties(id, key, value, created, modified)
-VALUES (nextval('hibernate_sequence'), 'OptOutOn', 'false', current_timestamp, current_timestamp);
+VALUES (nextval('property.hibernate_sequence'), 'OptOutOn', 'false', current_timestamp, current_timestamp);
 
 --rollback DELETE FROM properties WHERE key = 'OptOutOn';

--- a/src/main/resources/db/changelog/v2023/add_optout_property.sql
+++ b/src/main/resources/db/changelog/v2023/add_optout_property.sql
@@ -1,4 +1,3 @@
 INSERT INTO property.properties(id, key, value, created, modified)
-VALUES (nextval('property.hibernate_sequence'), 'OptOutOn', 'false', current_timestamp, current_timestamp);
-
---rollback DELETE FROM properties WHERE key = 'OptOutOn';
+VALUES (nextval('property.hibernate_sequence'), 'OptOutOn', false, current_timestamp, current_timestamp)
+ON CONFLICT (key) DO UPDATE SET value = false;

--- a/src/main/resources/db/changelog/v2023/create_properties.sql
+++ b/src/main/resources/db/changelog/v2023/create_properties.sql
@@ -1,5 +1,3 @@
-SELECT setval('property.property_sequence', max(id)) FROM property.properties;
-
 CREATE SEQUENCE IF NOT EXISTS hibernate_sequence START WITH 1 INCREMENT BY 1;
 
 INSERT INTO property.properties (id, key, value)
@@ -17,3 +15,5 @@ INSERT INTO property.properties(id, key, value, created, modified)
 VALUES (nextval('hibernate_sequence'), 'coverage.update.override', 'false', current_timestamp, current_timestamp),
        (nextval('hibernate_sequence'), 'coverage.update.months.past', '3', current_timestamp, current_timestamp),
        (nextval('hibernate_sequence'), 'coverage.update.stuck.hours', '24', current_timestamp, current_timestamp)
+
+SELECT setval('property.property_sequence', max(id)) FROM property.properties;

--- a/src/main/resources/db/changelog/v2023/create_properties.sql
+++ b/src/main/resources/db/changelog/v2023/create_properties.sql
@@ -14,6 +14,6 @@ VALUES ((select nextval('hibernate_sequence')), 'hpms.ingest.engaged', 'engaged'
 INSERT INTO property.properties(id, key, value, created, modified)
 VALUES (nextval('hibernate_sequence'), 'coverage.update.override', 'false', current_timestamp, current_timestamp),
        (nextval('hibernate_sequence'), 'coverage.update.months.past', '3', current_timestamp, current_timestamp),
-       (nextval('hibernate_sequence'), 'coverage.update.stuck.hours', '24', current_timestamp, current_timestamp)
+       (nextval('hibernate_sequence'), 'coverage.update.stuck.hours', '24', current_timestamp, current_timestamp);
 
 SELECT setval('property.property_sequence', max(id)) FROM property.properties;

--- a/src/main/resources/db/changelog/v2023/create_properties.sql
+++ b/src/main/resources/db/changelog/v2023/create_properties.sql
@@ -1,3 +1,5 @@
+SELECT setval('property.property_sequence', max(id)) FROM property.properties;
+
 CREATE SEQUENCE IF NOT EXISTS hibernate_sequence START WITH 1 INCREMENT BY 1;
 
 INSERT INTO property.properties (id, key, value)

--- a/src/main/resources/db/changelog/v2023/create_properties.sql
+++ b/src/main/resources/db/changelog/v2023/create_properties.sql
@@ -1,20 +1,53 @@
 CREATE SEQUENCE IF NOT EXISTS property.hibernate_sequence START WITH 1 INCREMENT BY 1;
 
 INSERT INTO property.properties (id, key, value)
-VALUES ((select nextval('property.hibernate_sequence')), 'hpms.ingest.engaged', 'engaged'),
-       ((select nextval('property.hibernate_sequence')), 'pcp.core.pool.size', 10),
-       ((select nextval('property.hibernate_sequence')), 'pcp.max.pool.size', 150),
-       ((select nextval('property.hibernate_sequence')), 'pcp.scaleToMax.time', 900),
-       ((select nextval('property.hibernate_sequence')), 'maintenance.mode', 'false'),
-       ((select nextval('property.hibernate_sequence')), 'worker.engaged', 'engaged'),
-       ((select nextval('property.hibernate_sequence')), 'coverage.update.discovery', 'idle'),
-       ((select nextval('property.hibernate_sequence')), 'coverage.update.queueing', 'idle'),
-       ((select nextval('property.hibernate_sequence')), 'ZipSupportOn', 'false');
+VALUES ((select nextval('property.hibernate_sequence')), 'hpms.ingest.engaged', 'engaged')
+ON CONFLICT (key) DO UPDATE SET value = 'engaged';
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('property.hibernate_sequence')), 'pcp.core.pool.size', 10)
+ON CONFLICT (key) DO UPDATE SET value = 10;
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('property.hibernate_sequence')), 'pcp.max.pool.size', 150)
+ON CONFLICT (key) DO UPDATE SET value = 150;
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('property.hibernate_sequence')), 'pcp.scaleToMax', 900)
+ON CONFLICT (key) DO UPDATE SET value = 900;
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('property.hibernate_sequence')), 'maintenance.mode', false)
+ON CONFLICT (key) DO UPDATE SET value = false;
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('property.hibernate_sequence')), 'worker.engaged', 'engaged')
+ON CONFLICT (key) DO UPDATE SET value = 'engaged';
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('property.hibernate_sequence')), 'coverage.update.discovery', 'idle')
+ON CONFLICT (key) DO UPDATE SET value = 'idle';
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('property.hibernate_sequence')), 'coverage.update.queueing', 'idle')
+ON CONFLICT (key) DO UPDATE SET value = 'idle';
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('property.hibernate_sequence')), 'ZipSupportOn', false)
+ON CONFLICT (key) DO UPDATE SET value = false;
+
 
 INSERT INTO property.properties(id, key, value, created, modified)
-VALUES (nextval('property.hibernate_sequence'), 'coverage.update.override', 'false', current_timestamp, current_timestamp),
-       (nextval('property.hibernate_sequence'), 'coverage.update.months.past', '3', current_timestamp, current_timestamp),
-       (nextval('property.hibernate_sequence'), 'coverage.update.stuck.hours', '24', current_timestamp, current_timestamp);
+VALUES (nextval('property.hibernate_sequence'), 'coverage.update.override', false, current_timestamp, current_timestamp)
+ON CONFLICT (key) DO UPDATE SET value = false;
+
+INSERT INTO property.properties(id, key, value, created, modified)
+VALUES (nextval('property.hibernate_sequence'), 'coverage.update.months.past', 3, current_timestamp, current_timestamp)
+ON CONFLICT (key) DO UPDATE SET value = 3;
+
+INSERT INTO property.properties(id, key, value, created, modified)
+VALUES (nextval('property.hibernate_sequence'), 'coverage.update.stuck.hours', 24, current_timestamp, current_timestamp)
+ON CONFLICT (key) DO UPDATE SET value = 24;
 
 SELECT setval('property.property_sequence', (SELECT max(id) FROM property.properties)+1);
 

--- a/src/main/resources/db/changelog/v2023/create_properties.sql
+++ b/src/main/resources/db/changelog/v2023/create_properties.sql
@@ -1,0 +1,17 @@
+CREATE SEQUENCE IF NOT EXISTS hibernate_sequence START WITH 1 INCREMENT BY 1;
+
+INSERT INTO property.properties (id, key, value)
+VALUES ((select nextval('hibernate_sequence')), 'hpms.ingest.engaged', 'engaged'),
+       ((select nextval('hibernate_sequence')), 'pcp.core.pool.size', 10),
+       ((select nextval('hibernate_sequence')), 'pcp.max.pool.size', 150),
+       ((select nextval('hibernate_sequence')), 'pcp.scaleToMax.time', 900),
+       ((select nextval('hibernate_sequence')), 'maintenance.mode', 'false'),
+       ((select nextval('hibernate_sequence')), 'worker.engaged', 'engaged'),
+       ((select nextval('hibernate_sequence')), 'coverage.update.discovery', 'idle'),
+       ((select nextval('hibernate_sequence')), 'coverage.update.queueing', 'idle'),
+       ((select nextval('hibernate_sequence')), 'ZipSupportOn', 'false');
+
+INSERT INTO property.properties(id, key, value, created, modified)
+VALUES (nextval('hibernate_sequence'), 'coverage.update.override', 'false', current_timestamp, current_timestamp),
+       (nextval('hibernate_sequence'), 'coverage.update.months.past', '3', current_timestamp, current_timestamp),
+       (nextval('hibernate_sequence'), 'coverage.update.stuck.hours', '24', current_timestamp, current_timestamp)

--- a/src/main/resources/db/changelog/v2023/create_properties.sql
+++ b/src/main/resources/db/changelog/v2023/create_properties.sql
@@ -1,20 +1,20 @@
-CREATE SEQUENCE IF NOT EXISTS hibernate_sequence START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS property.hibernate_sequence START WITH 1 INCREMENT BY 1;
 
 INSERT INTO property.properties (id, key, value)
-VALUES ((select nextval('hibernate_sequence')), 'hpms.ingest.engaged', 'engaged'),
-       ((select nextval('hibernate_sequence')), 'pcp.core.pool.size', 10),
-       ((select nextval('hibernate_sequence')), 'pcp.max.pool.size', 150),
-       ((select nextval('hibernate_sequence')), 'pcp.scaleToMax.time', 900),
-       ((select nextval('hibernate_sequence')), 'maintenance.mode', 'false'),
-       ((select nextval('hibernate_sequence')), 'worker.engaged', 'engaged'),
-       ((select nextval('hibernate_sequence')), 'coverage.update.discovery', 'idle'),
-       ((select nextval('hibernate_sequence')), 'coverage.update.queueing', 'idle'),
-       ((select nextval('hibernate_sequence')), 'ZipSupportOn', 'false');
+VALUES ((select nextval('property.hibernate_sequence')), 'hpms.ingest.engaged', 'engaged'),
+       ((select nextval('property.hibernate_sequence')), 'pcp.core.pool.size', 10),
+       ((select nextval('property.hibernate_sequence')), 'pcp.max.pool.size', 150),
+       ((select nextval('property.hibernate_sequence')), 'pcp.scaleToMax.time', 900),
+       ((select nextval('property.hibernate_sequence')), 'maintenance.mode', 'false'),
+       ((select nextval('property.hibernate_sequence')), 'worker.engaged', 'engaged'),
+       ((select nextval('property.hibernate_sequence')), 'coverage.update.discovery', 'idle'),
+       ((select nextval('property.hibernate_sequence')), 'coverage.update.queueing', 'idle'),
+       ((select nextval('property.hibernate_sequence')), 'ZipSupportOn', 'false');
 
 INSERT INTO property.properties(id, key, value, created, modified)
-VALUES (nextval('hibernate_sequence'), 'coverage.update.override', 'false', current_timestamp, current_timestamp),
-       (nextval('hibernate_sequence'), 'coverage.update.months.past', '3', current_timestamp, current_timestamp),
-       (nextval('hibernate_sequence'), 'coverage.update.stuck.hours', '24', current_timestamp, current_timestamp);
+VALUES (nextval('property.hibernate_sequence'), 'coverage.update.override', 'false', current_timestamp, current_timestamp),
+       (nextval('property.hibernate_sequence'), 'coverage.update.months.past', '3', current_timestamp, current_timestamp),
+       (nextval('property.hibernate_sequence'), 'coverage.update.stuck.hours', '24', current_timestamp, current_timestamp);
 
 SELECT setval('property.property_sequence', (SELECT max(id) FROM property.properties)+1);
 

--- a/src/main/resources/db/changelog/v2023/create_properties.sql
+++ b/src/main/resources/db/changelog/v2023/create_properties.sql
@@ -16,4 +16,5 @@ VALUES (nextval('hibernate_sequence'), 'coverage.update.override', 'false', curr
        (nextval('hibernate_sequence'), 'coverage.update.months.past', '3', current_timestamp, current_timestamp),
        (nextval('hibernate_sequence'), 'coverage.update.stuck.hours', '24', current_timestamp, current_timestamp);
 
-SELECT setval('property.property_sequence', max(id)) FROM property.properties;
+SELECT setval('property.property_sequence', (SELECT max(id) FROM property.properties)+1);
+


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5434

## 🛠 Changes

Created liquibase file create_properties.sql
Moved add_optout_property.sql from ab2d repo to ab2d-properties

## ℹ️ Context for reviewers

Similar to the events and contract service, move the management of the schema from the AB2D repo to the properties repo. Need to work with Liquibase and moved out of the main AB2D repository.

## ✅ Acceptance Validation

Tested locally and compared with prod:

Local:

<img width="950" alt="Screenshot 2023-09-25 at 1 16 30 PM" src="https://github.com/CMSgov/ab2d-properties/assets/132938234/aac86dfa-aa51-4604-bf1e-7b8ae5aaa4bb">

Prod:
<img width="1008" alt="Screenshot 2023-09-25 at 1 09 06 PM" src="https://github.com/CMSgov/ab2d-properties/assets/132938234/4d9a6b23-fa6b-4fa5-b82b-c1f0d5b22bad">

Additionally, deployed on Impl. Job executed successfully

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
