### PR TITLE
[AB2D-6289] Resolve Snyk Vulnerabilities - Upgrade Springboot Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.0'
+    id 'org.springframework.boot' version '3.2.8'
     id 'com.jfrog.artifactory' version '4.33.1' apply false
     id "org.sonarqube" version "4.3.0.3225"
     id "gov.cms.ab2d.plugin" version "1.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
- //   id 'org.springframework.boot' version '3.2.8'
+    id 'org.springframework.boot' version '3.2.8'
     id 'com.jfrog.artifactory' version '4.33.1' apply false
     id "org.sonarqube" version "4.3.0.3225"
     id "gov.cms.ab2d.plugin" version "1.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.8'
+ //   id 'org.springframework.boot' version '3.2.8'
     id 'com.jfrog.artifactory' version '4.33.1' apply false
     id "org.sonarqube" version "4.3.0.3225"
     id "gov.cms.ab2d.plugin" version "1.0.2"
@@ -17,6 +17,10 @@ repositories {
     mavenLocal()
 }
 
+compileJava {
+    options.compilerArgs << "-parameters"
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport // report is always generated after tests run
@@ -27,8 +31,8 @@ def jacksonCore = '2.15.2'
 def validationVersion = '2.0.1.Final'
 def springBootVersion = '3.2.8'
 def postgresVersion = '42.7.3'
-def testContainerVersion = '1.18.2'
-def liquibaseVersion = '4.19.0'
+def testContainerVersion = '1.20.1'
+def liquibaseVersion = '4.29.2'
 
 allprojects {
     apply plugin: 'gov.cms.ab2d.plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ test {
 def lombokVersion = '1.18.28'
 def jacksonCore = '2.15.2'
 def validationVersion = '2.0.1.Final'
-def springBootVersion = '2.7.5'
+def springBootVersion = '3.2.8'
 def springWebVersion = '5.3.26'
 def postgresVersion = '42.7.3'
 def testContainerVersion = '1.18.2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.5'
+    id 'org.springframework.boot' version '3.0.0'
     id 'com.jfrog.artifactory' version '4.33.1' apply false
     id "org.sonarqube" version "4.3.0.3225"
     id "gov.cms.ab2d.plugin" version "1.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ def lombokVersion = '1.18.28'
 def jacksonCore = '2.15.2'
 def validationVersion = '2.0.1.Final'
 def springBootVersion = '3.2.8'
-// def springWebVersion = '5.3.26'
 def postgresVersion = '42.7.3'
 def testContainerVersion = '1.18.2'
 def liquibaseVersion = '4.19.0'
@@ -40,8 +39,6 @@ allprojects {
         implementation "org.liquibase:liquibase-core:${liquibaseVersion}"
         implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-        // implementation "org.springframework:spring-web:${springWebVersion}"
-        // implementation "org.springframework:spring-webmvc:${springWebVersion}"
         implementation "com.fasterxml.jackson.core:jackson-core:${jacksonCore}"
         implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonCore}"
         implementation 'org.jetbrains:annotations:24.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ def lombokVersion = '1.18.28'
 def jacksonCore = '2.15.2'
 def validationVersion = '2.0.1.Final'
 def springBootVersion = '3.2.8'
-def springWebVersion = '5.3.26'
+// def springWebVersion = '5.3.26'
 def postgresVersion = '42.7.3'
 def testContainerVersion = '1.18.2'
 def liquibaseVersion = '4.19.0'
@@ -40,8 +40,8 @@ allprojects {
         implementation "org.liquibase:liquibase-core:${liquibaseVersion}"
         implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-        implementation "org.springframework:spring-web:${springWebVersion}"
-        implementation "org.springframework:spring-webmvc:${springWebVersion}"
+        // implementation "org.springframework:spring-web:${springWebVersion}"
+        // implementation "org.springframework:spring-webmvc:${springWebVersion}"
         implementation "com.fasterxml.jackson.core:jackson-core:${jacksonCore}"
         implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonCore}"
         implementation 'org.jetbrains:annotations:24.0.1'

--- a/src/main/java/gov/cms/ab2d/properties/controller/HealthCheckController.java
+++ b/src/main/java/gov/cms/ab2d/properties/controller/HealthCheckController.java
@@ -7,7 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import javax.sql.DataSource;
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/src/main/java/gov/cms/ab2d/properties/model/Property.java
+++ b/src/main/java/gov/cms/ab2d/properties/model/Property.java
@@ -5,12 +5,12 @@ import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6289

## 🛠 Changes

Updates Springboot framework version to 3.2.8 (as discussed on slack, this should match other repositories Anna has worked on).

Removes separation of Spring Web framework - this should no longer be needed. We can just use the default that comes with Springboot-starter for 3.2.8

## ℹ️ Context

We need to update the springboot framework to 3.X+ to resolve snyk vulnerabilities.

## 🧪 Validation

To be deployed to a lower environment together when other repositories have a springboot upgrade branch.