### PR TITLE
Update container image to amazoncorretto:21-al2023-jdk

### DIFF
--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -46,13 +46,13 @@ jobs:
 
       - name: Build and push docker image
         run: |
+      - name: Build and push docker image
+        run: |
           ECR_DOMAIN="$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
           SHA_SHORT=$(git rev-parse --short HEAD)
           aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_DOMAIN
           ECR_URI="$ECR_DOMAIN/$ECR_REPO"
-          
-          TAG_SHORT="$TAG_PREFIX-$GITHUB_REF_NAME"
-          
+          TAG_SHORT="$TAG_PREFIX-$GITHUB_REF_NAME-$SHA_SHORT"
           docker build -t "$ECR_URI:$TAG_SHORT" .
           docker push "$ECR_URI" --all-tags
           echo "Published **$ECR_URI:$TAG_SHORT**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Build and push docker image
         run: |
-      - name: Build and push docker image
-        run: |
           ECR_DOMAIN="$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
           SHA_SHORT=$(git rev-parse --short HEAD)
           aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_DOMAIN

--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -1,5 +1,5 @@
 name: Deploy Properties GF
-run-name: deploy-gf ${{ inputs.environment }} ${{ inputs.image_tag_suffix }}
+run-name: deploy-gf ${{ inputs.environment }} ${{ inputs.image_tag }}
 
 on:
   workflow_call:
@@ -7,7 +7,7 @@ on:
       environment:
         required: true
         type: string
-      tag_suffix:
+      image_tag:
         required: true
         type: string
   workflow_dispatch:
@@ -21,9 +21,9 @@ on:
           - test
           - sandbox
           - prod
-      image_tag_suffix:
-        description: Image tag suffix
-        required: false
+      image_tag:
+        description: ECR image tag for selected module (properties-service-<branch>-<SHA>)
+        required: true
         type: string
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
 
     with:
       environment: ${{ inputs.environment }}
-      properties_service_image: properties-service-${{ inputs.image_tag_suffix || github.ref }}
+      properties_service_image: ${{ inputs.image_tag }}
       apply: true
       ref: main
       runner: codebuild-ab2d-properties-${{github.run_id}}-${{github.run_attempt}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-al2-jdk
+FROM amazoncorretto:21-al2023-jdk
 WORKDIR /usr/src/ab2d-properties
 # ADD build/libs/Ab2d-*-Properties-Service-*.jar /usr/src/ab2d-properties/ab2d-properties.jar
 ADD build/libs/ab2d-properties-*.jar /usr/src/ab2d-properties/ab2d-properties.jar


### PR DESCRIPTION
## 🎫 Ticket

- https://jira.cms.gov/browse/AB2D-6812
- https://jira.cms.gov/browse/AB2D-6766

## 🛠 Changes

- Update `Dockerfile` to use **amazoncorretto:21-al2023-jdk** container image
- Minor cleanup in workflow

## ℹ️ Context

From Brian Hodges:
```
Please move to a supported tagged release that is not AL2-based. 17-al2023-jdk should be a straightforward. This needs to occur for all containerized AB2D services.
```

Folks have reported better memory usage using correta 21.  

## 🧪 Validation

Validated in `dev`.

https://github.com/CMSgov/ab2d-properties/actions/runs/16498845220
