### PR TITLE
Update build-gf.yml to format branch name in ECR image tag  

### DIFF
--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -50,7 +50,8 @@ jobs:
           SHA_SHORT=$(git rev-parse --short HEAD)
           aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_DOMAIN
           ECR_URI="$ECR_DOMAIN/$ECR_REPO"
-          TAG_SHORT="$TAG_PREFIX-$GITHUB_REF_NAME-$SHA_SHORT"
+          BRANCH_NAME_FORMATTED=${GITHUB_REF_NAME//\//-}
+          TAG_SHORT="$TAG_PREFIX-$BRANCH_NAME_FORMATTED-$SHA_SHORT"
           docker build -t "$ECR_URI:$TAG_SHORT" .
           docker push "$ECR_URI" --all-tags
           echo "Published **$ECR_URI:$TAG_SHORT**" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6815

## 🛠 Changes

Update `build-gf.yml` to replace `/` with `-` in branch name because ECR doesn't accept slashes

## ℹ️ Context

A branch named e.g. **ab2d-6815/fix-build** would be formatted to **ab2d-5815-fix-build** when creating the ECR image tag. 

## 🧪 Validation

https://github.com/CMSgov/ab2d-properties/actions/runs/16576460740